### PR TITLE
Fix SKILL.md frontmatter: remove invalid argument-hint field

### DIFF
--- a/skills/present-json/SKILL.md
+++ b/skills/present-json/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: present-json
-description: Present JSON results to humans via an interactive browser viewer. Use this when you have JSON output (API responses, data analysis, configs, etc.) that would benefit from visual exploration rather than raw text in the terminal.
-argument-hint: [json-content-or-file-path] [tab-name]
+description: Present JSON results to humans via an interactive browser viewer. Use this when you have JSON output (API responses, data analysis, configs, etc.) that would benefit from visual exploration rather than raw text in the terminal. Usage: /present-json [json-content-or-file-path] [tab-name]
 allowed-tools: Bash
 ---
 


### PR DESCRIPTION
Move argument hint into description field. Per the SKILL.md spec, only name, description, license, allowed-tools, metadata, and compatibility are valid frontmatter fields.

https://claude.ai/code/session_01UnUwTsJBSirBdA5qRpBs6s